### PR TITLE
feat(ci): #DEVOPS-4001 update cron schedule and install additional tools

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   schedule:
-    - cron: '26 1 * * *'
+    - cron: '15 1 * * *'
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,57 @@
 FROM docker.io/node:lts-alpine3.20
 
 # Set shell to use pipefail for safer piping
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
-
-# Pin package versions (replace x.y.z with actual versions)
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam && \
-    apk add --no-cache bash sudo shadow jq && \
-    apk del .pipeline-deps
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
-RUN apk add --no-cache curl openssl docker-cli git openssh-client yq
+# Install base packages and Azure DevOps dependencies
+RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam && \
+    apk add --no-cache bash sudo shadow jq curl openssl docker-cli docker-cli-buildx git openssh-client yq ca-certificates && \
+    apk del .pipeline-deps
 
 # Resolve Dependencies [trivy]
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.18.3
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.55.2
 
 # Resolve Dependencies [Helm]
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.16.2 bash
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.16.3 bash
 
 # Resolve Dependencies [ArgoCD]
-RUN curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.14.5/argocd-linux-amd64 && chmod +x /usr/local/bin/argocd
+RUN curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.14.7/argocd-linux-amd64 && chmod +x /usr/local/bin/argocd
 
 # Resolve Dependencies [kubectl]
-RUN curl -o /usr/local/bin/kubectl -L "https://dl.k8s.io/release/v1.28.5/bin/linux/amd64/kubectl" && chmod +x /usr/local/bin/kubectl
+RUN curl -o /usr/local/bin/kubectl -L "https://dl.k8s.io/release/v1.31.2/bin/linux/amd64/kubectl" && chmod +x /usr/local/bin/kubectl
 
+# Resolve Dependencies [hadolint]
 RUN curl -o /usr/local/bin/hadolint -L "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64" && chmod +x /usr/local/bin/hadolint
+
+# Install k6
+RUN curl -L "https://github.com/grafana/k6/releases/download/v0.51.0/k6-v0.51.0-linux-amd64.tar.gz" \
+    | tar xz -C /tmp && \
+    mv /tmp/k6-v0.51.0-linux-amd64/k6 /usr/local/bin/k6 && \
+    chmod +x /usr/local/bin/k6 && \
+    rm -rf /tmp/k6-v0.51.0-linux-amd64
+
+# Install GitHub CLI (gh)
+RUN GH_VERSION="2.49.0" && \
+    wget -qO- "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar xz -C /tmp && \
+    mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh && \
+    chmod +x /usr/local/bin/gh && \
+    rm -rf /tmp/gh_${GH_VERSION}_linux_amd64
+
+# Create Azure DevOps agent user
+RUN adduser -D -s /bin/bash azp
+
+# Set up docker group and add azp user to it
+RUN addgroup docker && adduser azp docker
+
+# Configure sudo for azp user
+RUN echo "azp ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Set working directory
+WORKDIR /azp
+
+# Set environment variables for Azure DevOps
+ENV AGENT_ALLOW_RUNASROOT=1
 
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
The changes in this commit update the cron schedule for the Docker publish workflow and install additional tools required for the CI/CD pipeline.

The cron schedule has been updated from `26 1 * * *` to `15 1 * * *` to run the workflow at a different time.

The Dockerfile has been updated to install the following additional tools:
- curl, openssl, docker-cli, git, openssh-client, yq, ca-certificates
- Trivy v0.55.2
- Helm v3.16.3
- ArgoCD v2.14.7
- kubectl v1.31.2
- hadolint v2.12.0
- k6 v0.51.0
- GitHub CLI (gh) v2.49.0

The Dockerfile also creates an Azure DevOps agent user, sets up the Docker group, and configures sudo for the agent user. The working directory is set to `/azp`, and the necessary environment variables for Azure DevOps are set.

These changes ensure that the CI/CD pipeline has access to the required tools and dependencies to perform various tasks, such as container image scanning, Helm chart management, and Kubernetes deployment.